### PR TITLE
Systemd compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ $ DISK_USAGE_MOUNTPOINT=/dev/vdb ./metrics.sh -m disk_usage
 
 ### Configuration files
 
-Maintaing all these options can become a cumbersome job, but metrics.sh provides functionality for creating and reading configuration files.
+Maintaining all these options can become a cumbersome job, but metrics.sh provides functionality for creating and reading configuration files.
 
 ```sh
 $ ./metrics.sh -C > metrics.ini  # write configuration to metrics.ini
@@ -152,7 +152,7 @@ defaults () {}  # setting default variables
 start () {}     # called at the beginning
 collect () {}   # collect the actual metric
 stop () {}      # called before exiting
-docs () {}      # used for priting docs and creating output for configuration
+docs () {}      # used for printing docs and creating output for configuration
 ```
 
 Metrics run within an isolated scope. It's generally safe to create variables and helper functions within metrics.
@@ -215,7 +215,7 @@ defaults () {}  # setting default variables
 start () {}     # called at the beginning
 report () {}    # report the actual metric
 stop () {}      # called before exiting
-docs () {}      # used for priting docs and creating output for configuration
+docs () {}      # used for printing docs and creating output for configuration
 ```
 
 Below is an example script for sending metrics as JSON data to an API endpoint. Assuming this script is located at `./reporters/custom/json_api.sh`, it can be invoked by calling `./metrics.sh -r json_api`.
@@ -231,7 +231,7 @@ defaults () {
 }
 
 # Prepare the reporter. Create helper functions to be used during collection
-# if needed. Returning 1 will result in an error and exection will be stopped.
+# if needed. Returning 1 will result in an error and execution will be stopped.
 start () {
   if [ -z $JSON_API_ENDPOINT ]; then
     echo "Error: json_api requires \$JSON_API_ENDPOINT to be specified"

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ $ git clone https://github.com/pstadler/metrics.sh.git
 ```
 
 See this [guide](init.d/README.md) how to run metrics.sh as a service on Linux.
+Or [here](systemd/README.md) for instructions to set metrics.sh up for systemd.
 
 ### Requirements
 

--- a/lib/main.sh
+++ b/lib/main.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # load utils
-for util in ./lib/utils/*.sh; do
+for util in ${DIR}/lib/utils/*.sh; do
   . $util
 done
 
@@ -16,10 +16,10 @@ main_defaults () {
     DEFAULT_REPORTER=stdout
   fi
   if [ -z $CUSTOM_REPORTERS_PATH ]; then
-    CUSTOM_REPORTERS_PATH=./reporters/custom
+    CUSTOM_REPORTERS_PATH=${DIR}/reporters/custom
   fi
   if [ -z $CUSTOM_METRICS_PATH ]; then
-    CUSTOM_METRICS_PATH=./metrics/custom
+    CUSTOM_METRICS_PATH=${DIR}/metrics/custom
   fi
 }
 

--- a/lib/main.sh
+++ b/lib/main.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # load utils
-for util in ${PWD}/lib/utils/*.sh; do
+for util in ${DIR}/lib/utils/*.sh; do
   . $util
 done
 
@@ -16,10 +16,10 @@ main_defaults () {
     DEFAULT_REPORTER=stdout
   fi
   if [ -z $CUSTOM_REPORTERS_PATH ]; then
-    CUSTOM_REPORTERS_PATH=${PWD}/reporters/custom
+    CUSTOM_REPORTERS_PATH=${DIR}/reporters/custom
   fi
   if [ -z $CUSTOM_METRICS_PATH ]; then
-    CUSTOM_METRICS_PATH=${PWD}/metrics/custom
+    CUSTOM_METRICS_PATH=${DIR}/metrics/custom
   fi
 }
 

--- a/lib/main.sh
+++ b/lib/main.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # load utils
-for util in ${DIR}/lib/utils/*.sh; do
+for util in ${PWD}/lib/utils/*.sh; do
   . $util
 done
 
@@ -16,10 +16,10 @@ main_defaults () {
     DEFAULT_REPORTER=stdout
   fi
   if [ -z $CUSTOM_REPORTERS_PATH ]; then
-    CUSTOM_REPORTERS_PATH=${DIR}/reporters/custom
+    CUSTOM_REPORTERS_PATH=${PWD}/reporters/custom
   fi
   if [ -z $CUSTOM_METRICS_PATH ]; then
-    CUSTOM_METRICS_PATH=${DIR}/metrics/custom
+    CUSTOM_METRICS_PATH=${PWD}/metrics/custom
   fi
 }
 

--- a/lib/utils/loader.sh
+++ b/lib/utils/loader.sh
@@ -2,7 +2,7 @@
 
 get_available_reporters () {
   local result
-  for file in `ls ./reporters/*.sh $CUSTOM_REPORTERS_PATH/*.sh 2> /dev/null`; do
+  for file in `ls ${DIR}/reporters/*.sh $CUSTOM_REPORTERS_PATH/*.sh 2> /dev/null`; do
     local filename=$(basename $file)
     local reporter=${filename%.*}
     result=$(echo "$result $reporter")
@@ -12,7 +12,7 @@ get_available_reporters () {
 
 get_available_metrics () {
   local result
-  for file in `ls ./metrics/*.sh $CUSTOM_METRICS_PATH/*.sh 2> /dev/null`; do
+  for file in `ls ${DIR}/metrics/*.sh $CUSTOM_METRICS_PATH/*.sh 2> /dev/null`; do
     local filename=$(basename $file)
     local metric=${filename%.*}
     # register metric
@@ -26,7 +26,7 @@ load_reporter_with_prefix () {
   local name=$2
 
   local file
-  for dir in $CUSTOM_REPORTERS_PATH ./reporters; do
+  for dir in $CUSTOM_REPORTERS_PATH ${DIR}/reporters; do
     if [ -f $dir/$name.sh ]; then
       file=$dir/$name.sh
       break
@@ -53,7 +53,7 @@ load_metric_with_prefix () {
   local name=$2
 
   local file
-  for dir in $CUSTOM_METRICS_PATH ./metrics; do
+  for dir in $CUSTOM_METRICS_PATH ${DIR}/metrics; do
     if [ -f $dir/$name.sh ]; then
       file=$dir/$name.sh
       break

--- a/lib/utils/loader.sh
+++ b/lib/utils/loader.sh
@@ -2,7 +2,7 @@
 
 get_available_reporters () {
   local result
-  for file in `ls ${DIR}/reporters/*.sh $CUSTOM_REPORTERS_PATH/*.sh 2> /dev/null`; do
+  for file in `ls ${PWD}/reporters/*.sh $CUSTOM_REPORTERS_PATH/*.sh 2> /dev/null`; do
     local filename=$(basename $file)
     local reporter=${filename%.*}
     result=$(echo "$result $reporter")
@@ -12,7 +12,7 @@ get_available_reporters () {
 
 get_available_metrics () {
   local result
-  for file in `ls ${DIR}/metrics/*.sh $CUSTOM_METRICS_PATH/*.sh 2> /dev/null`; do
+  for file in `ls ${PWD}/metrics/*.sh $CUSTOM_METRICS_PATH/*.sh 2> /dev/null`; do
     local filename=$(basename $file)
     local metric=${filename%.*}
     # register metric
@@ -26,7 +26,7 @@ load_reporter_with_prefix () {
   local name=$2
 
   local file
-  for dir in $CUSTOM_REPORTERS_PATH ${DIR}/reporters; do
+  for dir in $CUSTOM_REPORTERS_PATH ${PWD}/reporters; do
     if [ -f $dir/$name.sh ]; then
       file=$dir/$name.sh
       break
@@ -53,7 +53,7 @@ load_metric_with_prefix () {
   local name=$2
 
   local file
-  for dir in $CUSTOM_METRICS_PATH ${DIR}/metrics; do
+  for dir in $CUSTOM_METRICS_PATH ${PWD}/metrics; do
     if [ -f $dir/$name.sh ]; then
       file=$dir/$name.sh
       break

--- a/lib/utils/loader.sh
+++ b/lib/utils/loader.sh
@@ -2,7 +2,7 @@
 
 get_available_reporters () {
   local result
-  for file in `ls ${PWD}/reporters/*.sh $CUSTOM_REPORTERS_PATH/*.sh 2> /dev/null`; do
+  for file in `ls ${DIR}/reporters/*.sh $CUSTOM_REPORTERS_PATH/*.sh 2> /dev/null`; do
     local filename=$(basename $file)
     local reporter=${filename%.*}
     result=$(echo "$result $reporter")
@@ -12,7 +12,7 @@ get_available_reporters () {
 
 get_available_metrics () {
   local result
-  for file in `ls ${PWD}/metrics/*.sh $CUSTOM_METRICS_PATH/*.sh 2> /dev/null`; do
+  for file in `ls ${DIR}/metrics/*.sh $CUSTOM_METRICS_PATH/*.sh 2> /dev/null`; do
     local filename=$(basename $file)
     local metric=${filename%.*}
     # register metric
@@ -26,7 +26,7 @@ load_reporter_with_prefix () {
   local name=$2
 
   local file
-  for dir in $CUSTOM_REPORTERS_PATH ${PWD}/reporters; do
+  for dir in $CUSTOM_REPORTERS_PATH ${DIR}/reporters; do
     if [ -f $dir/$name.sh ]; then
       file=$dir/$name.sh
       break
@@ -53,7 +53,7 @@ load_metric_with_prefix () {
   local name=$2
 
   local file
-  for dir in $CUSTOM_METRICS_PATH ${PWD}/metrics; do
+  for dir in $CUSTOM_METRICS_PATH ${DIR}/metrics; do
     if [ -f $dir/$name.sh ]; then
       file=$dir/$name.sh
       break

--- a/metrics.sh
+++ b/metrics.sh
@@ -4,7 +4,7 @@
 LC_ALL=en_US.UTF-8
 LANG=en_US.UTF-8
 LANGUAGE=en_US.UTF-8
-DIR=$(dirname "$(readlink -f "$0")")
+PWD=$(dirname "$0")
 
 usage () {
   echo "  Usage: $0 [-d] [-h] [-v] [-c] [-m] [-r] [-i] [-C] [-u]"
@@ -91,7 +91,7 @@ while [ $# -gt 0 ]; do
 done
 
 # run
-. ${DIR}/lib/main.sh
+. ${PWD}/lib/main.sh
 
 if [ $opt_do_update = true ]; then
   if ! command_exists git; then

--- a/metrics.sh
+++ b/metrics.sh
@@ -4,6 +4,7 @@
 LC_ALL=en_US.UTF-8
 LANG=en_US.UTF-8
 LANGUAGE=en_US.UTF-8
+DIR=$(dirname "$(readlink -f "$0")")
 
 usage () {
   echo "  Usage: $0 [-d] [-h] [-v] [-c] [-m] [-r] [-i] [-C] [-u]"
@@ -90,7 +91,7 @@ while [ $# -gt 0 ]; do
 done
 
 # run
-. ./lib/main.sh
+. ${DIR}/lib/main.sh
 
 if [ $opt_do_update = true ]; then
   if ! command_exists git; then

--- a/metrics.sh
+++ b/metrics.sh
@@ -4,7 +4,7 @@
 LC_ALL=en_US.UTF-8
 LANG=en_US.UTF-8
 LANGUAGE=en_US.UTF-8
-PWD=$(dirname "$0")
+DIR=$(dirname "$0")
 
 usage () {
   echo "  Usage: $0 [-d] [-h] [-v] [-c] [-m] [-r] [-i] [-C] [-u]"
@@ -91,7 +91,7 @@ while [ $# -gt 0 ]; do
 done
 
 # run
-. ${PWD}/lib/main.sh
+. ${DIR}/lib/main.sh
 
 if [ $opt_do_update = true ]; then
   if ! command_exists git; then

--- a/systemd/README.md
+++ b/systemd/README.md
@@ -23,9 +23,9 @@ $ systemctl daemon-reload
 $ systemctl start metrics.sh.service
 
 # If run with the default configuration where reporter is 'stdout', metrics
-# will be written to /var/log/metrics.sh.log. Be aware that this file will
-# grow fast.
-$ tail -f /var/log/metrics.sh.log
+# will be written to the journal. See the log using `journalctl -u metrics.sh`
+# or follow it with:
+$ journalctl -f -u metrics.sh
 
 # Stop service
 $ systemctl stop metrics.sh.service

--- a/systemd/README.md
+++ b/systemd/README.md
@@ -1,0 +1,41 @@
+# Running metrics.sh as a systemd service on Linux
+
+Run the following commands as root:
+
+```sh
+# Install metrics.sh at /opt/metrics.sh
+$ mkdir /opt; cd /opt
+$ git clone https://github.com/pstadler/metrics.sh.git
+$ cd metrics.sh
+# Install the service
+$ cp -p $PWD/systemd/metrics.sh.service /etc/systemd/system/metrics.sh.service
+$ chmod 664 /etc/systemd/system/metrics.sh.service
+# Create a config file
+$ mkdir /etc/metrics.sh && chmod 600 /etc/metrics.sh
+$ ./metrics.sh -C > /etc/metrics.sh/metrics.ini
+# At this point you should edit your config file at
+# /etc/metrics.sh/metrics.ini
+
+# Reload systemd daemon
+$ systemctl daemon-reload
+
+# Start service
+$ systemctl start metrics.sh.service
+
+# If run with the default configuration where reporter is 'stdout', metrics
+# will be written to /var/log/metrics.sh.log. Be aware that this file will
+# grow fast.
+$ tail -f /var/log/metrics.sh.log
+
+# Stop service
+$ systemctl stop metrics.sh.service
+
+# Check service status
+$ systemctl status metrics.sh.service
+
+# Automatically start service when booting and stop when shutting down
+$ systemctl enable metrics.sh.service
+
+# Disable automatic starting/stopping
+$ systemctl disable metrics.sh.service
+```

--- a/systemd/README.md
+++ b/systemd/README.md
@@ -9,7 +9,6 @@ $ git clone https://github.com/pstadler/metrics.sh.git
 $ cd metrics.sh
 # Install the service
 $ cp -p $PWD/systemd/metrics.sh.service /etc/systemd/system/metrics.sh.service
-$ chmod 664 /etc/systemd/system/metrics.sh.service
 # Create a config file
 $ mkdir /etc/metrics.sh && chmod 600 /etc/metrics.sh
 $ ./metrics.sh -C > /etc/metrics.sh/metrics.ini

--- a/systemd/metrics.sh.service
+++ b/systemd/metrics.sh.service
@@ -1,5 +1,7 @@
 [Unit]
-Description=Server metrics collector
+Description=Controls the metrics daemon "metrics.sh"
+Documentation=https://github.com/pstadler/metrics.sh
+After=network.target
 
 [Service]
 ExecStart=/opt/metrics.sh/metrics.sh -c /etc/metrics.sh/metrics.ini

--- a/systemd/metrics.sh.service
+++ b/systemd/metrics.sh.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Server metrics collector
+
+[Service]
+ExecStart=/opt/metrics.sh/metrics.sh -c /etc/metrics.sh/metrics.ini
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/metrics.sh.service
+++ b/systemd/metrics.sh.service
@@ -5,6 +5,7 @@ After=network.target
 
 [Service]
 ExecStart=/opt/metrics.sh/metrics.sh -c /etc/metrics.sh/metrics.ini
+Restart=always
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
- Use of `$DIR/` instead of `./` to allow start from another location
- Service file for systemd with autostart capability after metrics.sh exits
- Short instruction how to setup metrics.sh for systemd
- Some typos corrected